### PR TITLE
Follow PHP best practices (no closing tag)

### DIFF
--- a/shellcheck.php
+++ b/shellcheck.php
@@ -20,4 +20,3 @@ if(is_resource($process)) {
 } else { 
   echo "[{ 'line': 1, 'column': 1, 'level': 'error', 'message': 'Oops, internal server error unrelated to your script! Sorry!'}]";
 }
-?>


### PR DESCRIPTION
Following PHP best practices, one should omit the closing tag on PHP-only files. http://www.php-fig.org/psr/psr-2/#2-2-files