### PR TITLE
unquote script if php has magic_quotes_gpc set

### DIFF
--- a/shellcheck.php
+++ b/shellcheck.php
@@ -5,6 +5,11 @@
 
 header('Content-type: application/json; charset=UTF-8');
 
+$script = $_POST["script"];
+if (get_magic_quotes_gpc()) {
+    $script = stripslashes($script);
+}
+
 $fds = array( 
     0 => array("pipe", "r"), 
     1 => array("pipe", "w"),
@@ -12,7 +17,7 @@ $fds = array(
 
 $process = proc_open("exec ./shellcheck.sh", $fds, $pipes);
 if(is_resource($process)) {
-  fwrite($pipes[0], $_POST["script"]);
+  fwrite($pipes[0], $script);
   fclose($pipes[0]);
   echo stream_get_contents($pipes[1]);
   fclose($pipes[1]);


### PR DESCRIPTION
In php-versions before 5.4 there is this option `magic_quotes_gpc` and it is set to on. This means that for all HTTP request data like `$_POST`
> all `'` (single-quote), `"` (double quote), `\` (backslash) and `NULL` characters are escaped with a backslash automatically. This is identical to what `addslashes()` does.

see: [PHP: What are Magic Quotes - Manual](http://php.net/manual/en/security.magicquotes.what.php)

For shellcheck it means, there are false error reports like this one:
```
Line 1:
        if [ -z "${CMAKE_TOOLCHAIN_FILE-""}" ]
                ^-- SC2157: Argument to -z is always false due to literal strings.
                  ^-- SC2086: Double quote to prevent globbing and word splitting.
```
You can get this result from a working version of shellchek, if you escape the quotes like so
``` sh
        if [ -z \"${CMAKE_TOOLCHAIN_FILE-""}\" ]
```
Fortunately the function `get_magic_quotes_gpc()` is present in all PHP versions and returns false when this feature is not present (either *off* or non existent) and so we can undo the escapes if necessary.