### PR TITLE
update readme & add link to this repository on index

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 shellcheck.net
 ==============
 
-ShellCheck's live demo website. Try it out on http://www.shellcheck.net
+ShellCheck's live demo website. Try it out on [shellcheck.net](http://www.shellcheck.net).
 
-To run locally, clone and build https://github.com/koalaman/ace and copy ace/build/src as libace here.
+To run locally, clone and build [koalaman/ace](https://github.com/koalaman/ace)
+and copy ace/build/src as libace here.  Note that src trees from the
+[ace-builds](https://github.com/ajaxorg/ace-builds/) repository will *not*
+function completely, if at all.
+
+A local test server can be run with `php -S localhost:8000` provided `php >= 5.4.0`.

--- a/index.php
+++ b/index.php
@@ -125,7 +125,12 @@ done
         </div>
       </div>
       <div class="contentpart">
-        Sounds awesome? <a href="https://github.com/koalaman/shellcheck">Read more about it</a> on the <a href="https://github.com/koalaman/shellcheck">GitHub page</a>!
+        <p>
+          Sounds awesome? <a href="https://github.com/koalaman/shellcheck">Read more about it</a> on the <a href="https://github.com/koalaman/shellcheck">GitHub page</a>!
+        </p>
+        <p>
+          This website is also open source <a href="https://github.com/koalaman/shellcheck.net">here</a>!
+        </p>
       </div>
     </div>
     <script src="libace/ace.js" type="text/javascript" charset="utf-8"></script>


### PR DESCRIPTION
Added a few observations I found as I got this up and running locally, and a link to the repo that I couldn't find until you pointed it out to me in #bash. When I have more time I'll see about submitting another PR to add raw (& normal?) link support. From my quick look it doesn't seem like the website actually supports direct links at all. Is that custom/integrated functionality with the shellcheck bot? I wrote up something for existing shortlinks and then realized I was serving `$content` instead of the shellcheck output, and it's a bit tricky due to the javascript hooks. And there doesn't seem to be any logic here to store things in `./data`.