### PR TITLE
Remove the default title from the generated template

### DIFF
--- a/bugreport.js
+++ b/bugreport.js
@@ -1,8 +1,6 @@
 var bugBaseUrl = "https://github.com/koalaman/shellcheck";
 
 function makeReportUrl(script, json) {
-  var title = "TODO: Add title";
-
   var template =
 		"#### For bugs\n" +
 		"- Rule Id (if any, e.g. SC1000): %ERRORS%\n" +
@@ -45,13 +43,5 @@ function makeReportUrl(script, json) {
 		.replace("%ERRORS%", errors)
 		.replace("%ACTUAL%", actual);
 
-	return newIssueUrl(bugBaseUrl, title, body);
+	return base + "/issues/new?body=" + encodeURIComponent(body);
 }
-
-function newIssueUrl(base, title, body) {
-	var url = base + "/issues/new?" +
-		"title=" + encodeURIComponent(title) +
-    "&body=" + encodeURIComponent(body) ;
-  return url;
-}
-


### PR DESCRIPTION
A number of users have accidentally filed bugs without updating the issue title ([18 so far](https://github.com/koalaman/shellcheck/search?q=todo%3A+add+title&type=Issues)); simply leaving the title out of the generated URL will force them to set a title in order to submit the issue.