### PR TITLE
Add MuseDev to list of CI services

### DIFF
--- a/index.php
+++ b/index.php
@@ -186,7 +186,7 @@ find backups/ \
             <li>available on <a href="https://github.com/koalaman/shellcheck">GitHub</a></li>
             <li>already packaged for your <a href="https://github.com/koalaman/shellcheck#user-content-installing">distro or package&nbsp;manager</a> </li>
             <li>supported as an <a href="https://github.com/koalaman/shellcheck#user-content-in-your-editor">integrated linter</a> in major&nbsp;editors</li>
-            <li>available in <a href="https://codeclimate.com/">CodeClimate</a>, <a href="https://www.codacy.com/">Codacy</a> and <a href="https://www.codefactor.io/">CodeFactor</a> to auto-check your GitHub repo</li>
+            <li>available in <a href="https://codeclimate.com/">CodeClimate</a>, <a href="https://www.codacy.com/">Codacy</a>, <a href="https://www.codefactor.io/">CodeFactor</a>, and <a href="https://muse.dev/">MuseDev</a> to auto-check your GitHub repo</li>
             <li>written in Haskell, if you're into that sort&nbsp;of&nbsp;thing.</li>
           </ul>
         </div>


### PR DESCRIPTION
Hello @koalaman! In short, can we add Muse to the list of CI services?

Muse.dev has been happily using shellcheck for a while now.  An example find is a [bug in the Curl CI scripts](https://console.muse.dev/result/TomMD/curl/01EEN20TVDZYMZYZDF1NZHMM1A?search=unquoted&tool=ShellCheck) which I [fixed](https://github.com/curl/curl/pull/5773).  Shellcheck now runs on all curl PRs, which is cool.  Oh, and fun side-note: MuseDev is mostly Haskell.