### PR TITLE
avoid calling removed function - PHP8 support

### DIFF
--- a/shellcheck.php
+++ b/shellcheck.php
@@ -10,7 +10,7 @@ function err($str) {
 header('Content-type: application/json; charset=UTF-8');
 
 $script = $_POST["script"];
-if (get_magic_quotes_gpc()) {
+if (function_exists('get_magic_quotes_gpc') && get_magic_quotes_gpc()) {
     $script = stripslashes($script);
 }
 


### PR DESCRIPTION
Confirm if get_magic_quotes_gpc() exists before attempting to execute, per #16 
Provides compatibility for PHP < 5.4, though this is likely dead code unless users have the very old PHP version.

Prevents a crash in PHP8 when calling the removed function, ex: `PHP Fatal error:  Uncaught Error: Call to undefined function get_magic_quotes_gpc() in /var/www/html/shellcheck.php`
