### PR TITLE
update the wiki link

### DIFF
--- a/index.php
+++ b/index.php
@@ -183,7 +183,7 @@ find backups/ \
         <div class="benefitblock">
           <ul>
             <li><a href="https://github.com/koalaman/shellcheck/blob/master/LICENSE">GPLv3</a>: free as in freedom</li>
-            <li>documented on the <a href="/wiki/Home">ShellCheck Wiki</a></li>
+            <li>documented on the <a href="https://github.com/koalaman/shellcheck/wiki">ShellCheck Wiki</a></li>
             <li>available on <a href="https://github.com/koalaman/shellcheck">GitHub</a> (as is <a href="https://github.com/koalaman/shellcheck.net">this website</a>)</li>
             <li>already packaged for your <a href="https://github.com/koalaman/shellcheck#user-content-installing">distro or package&nbsp;manager</a> </li>
             <li>supported as an <a href="https://github.com/koalaman/shellcheck#user-content-in-your-editor">integrated linter</a> in major&nbsp;editors</li>


### PR DESCRIPTION
the old link (https://www.shellcheck.net/wiki/Home) says "If you tried to follow a link for an issue but ended up here, it means that page does not exist yet :("